### PR TITLE
Change symbol reporter interface to allow opening any file

### DIFF
--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -9,8 +9,6 @@ package dotnet
 import (
 	"fmt"
 	"hash/fnv"
-	"os"
-	"path"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -631,11 +629,8 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 			info.simpleName, info.guid)
 
 		if !info.reported {
-			open := func() (process.ReadAtCloser, error) {
-				return os.Open(m.Path)
-			}
-			symbolReporter.ExecutableMetadata(info.fileID, path.Base(m.Path),
-				info.guid, libpf.Dotnet, open)
+			symbolReporter.ExecutableMetadata(info.fileID, m.Path,
+				info.guid, libpf.Dotnet, pr)
 			info.reported = true
 		}
 

--- a/process/coredump.go
+++ b/process/coredump.go
@@ -315,6 +315,11 @@ func (cd *CoredumpProcess) OpenELF(path string) (*pfelf.File, error) {
 	return nil, fmt.Errorf("ELF file `%s` not found", path)
 }
 
+// Open implements the FileOpener and Process interfaces
+func (cd *CoredumpProcess) Open(path string) (ReadAtCloser, string, error) {
+	return nil, path, errors.New("coredump does not support opening files")
+}
+
 // getFile returns (creating if needed) a matching CoredumpFile for given file name
 func (cd *CoredumpProcess) getFile(name string) *CoredumpFile {
 	if cf, ok := cd.files[name]; ok {

--- a/process/process.go
+++ b/process/process.go
@@ -252,3 +252,36 @@ func (sp *systemProcess) OpenELF(file string) (*pfelf.File, error) {
 	// Fall back to opening the file using the process specific root
 	return pfelf.Open(fmt.Sprintf("/proc/%v/root/%s", sp.pid, file))
 }
+
+type ReaderWithDummyClose struct {
+	io.ReaderAt
+}
+
+func (r *ReaderWithDummyClose) Close() error {
+	return nil
+}
+
+func (sp *systemProcess) Open(file string) (ReadAtCloser, string, error) {
+	// Always open via map_files as it can open deleted files if available.
+	// No fallback is attempted:
+	// - if the process exited, the fallback will error also (/proc/>PID> is gone)
+	// - if the error is due to ELF content, same error will occur in both cases
+	// - if the process unmapped the ELF, its data is no longer needed
+	if m, ok := sp.fileToMapping[file]; ok {
+		if m.IsVDSO() {
+			vdso, err := sp.extractMapping(m)
+			if err != nil {
+				return nil, "", fmt.Errorf("failed to extract VDSO: %v", err)
+			}
+			return &ReaderWithDummyClose{vdso}, "", nil
+		}
+		path := sp.getMappingFile(m)
+		f, err := os.Open(path)
+		return f, path, err
+	}
+
+	// Fall back to opening the file using the process specific root
+	path := fmt.Sprintf("/proc/%v/root/%s", sp.pid, file)
+	f, err := os.Open(path)
+	return f, path, err
+}

--- a/process/types.go
+++ b/process/types.go
@@ -92,6 +92,10 @@ type ReadAtCloser interface {
 	io.Closer
 }
 
+type FileOpener interface {
+	Open(string) (reader ReadAtCloser, actualPath string, err error)
+}
+
 // Process is the interface to inspect ELF coredump/process.
 // The current implementations do not allow concurrent access to this interface
 // from different goroutines. As an exception the ELFOpener and the returned
@@ -125,4 +129,6 @@ type Process interface {
 	io.Closer
 
 	pfelf.ELFOpener
+
+	FileOpener
 }

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -83,6 +83,11 @@ func (d *dummyProcess) Close() error {
 	return nil
 }
 
+func (d *dummyProcess) Open(file string) (process.ReadAtCloser, string, error) {
+	f, err := os.Open(file)
+	return f, file, err
+}
+
 func newTestProcess(pid libpf.PID) process.Process {
 	return &dummyProcess{pid: pid}
 }
@@ -255,7 +260,7 @@ type symbolReporterMockup struct{}
 func (s *symbolReporterMockup) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}
 
 func (s *symbolReporterMockup) ExecutableMetadata(_ libpf.FileID, _, _ string,
-	_ libpf.InterpreterType, _ reporter.ExecutableOpener) {
+	_ libpf.InterpreterType, _ process.FileOpener) {
 }
 
 func (s *symbolReporterMockup) FrameMetadata(_ libpf.FileID, _ libpf.AddressOrLineno,

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"syscall"
 	"time"
 
@@ -291,26 +290,13 @@ func (pm *ProcessManager) getELFInfo(pr process.Process, mapping *process.Mappin
 	}
 	pm.FileIDMapper.Set(hostFileID, fileID)
 
-	baseName := path.Base(mapping.Path)
-	if baseName == "/" {
-		// There are circumstances where there is no filename.
-		// E.g. kernel module 'bpfilter_umh' before Linux 5.9-rc1 uses
-		// fork_usermode_blob() and launches process with a blob without
-		// filename mapped in as the executable.
-		baseName = "<anonymous-blob>"
-	}
-
 	buildID, _ := ef.GetBuildID()
 	if buildID == "" {
 		// If the buildID is empty, try to get Go buildID.
 		buildID, _ = ef.GetGoBuildID()
 	}
 
-	mapping2 := *mapping // copy to avoid races if callee saves the closure
-	open := func() (process.ReadAtCloser, error) {
-		return pr.OpenMappingFile(&mapping2)
-	}
-	pm.reporter.ExecutableMetadata(fileID, baseName, buildID, libpf.Native, open)
+	pm.reporter.ExecutableMetadata(fileID, mapping.Path, buildID, libpf.Native, pr)
 
 	return info
 }

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -54,8 +54,6 @@ type TraceReporter interface {
 	SupportsReportTraceEvent() bool
 }
 
-type ExecutableOpener = func() (process.ReadAtCloser, error)
-
 type SymbolReporter interface {
 	// ReportFallbackSymbol enqueues a fallback symbol for reporting, for a given frame.
 	ReportFallbackSymbol(frameID libpf.FrameID, symbol string)
@@ -68,7 +66,7 @@ type SymbolReporter interface {
 	// wish to upload executables should NOT block this function to do so and instead just
 	// open the file and then enqueue the upload in the background.
 	ExecutableMetadata(fileID libpf.FileID, fileName, buildID string,
-		interp libpf.InterpreterType, open ExecutableOpener)
+		interp libpf.InterpreterType, opener process.FileOpener)
 
 	// FrameMetadata accepts metadata associated with a frame and caches this information before
 	// a periodic reporting to the backend.

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf/xsync"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/process"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
 )
 
@@ -207,7 +208,7 @@ func (r *OTLPReporter) ReportFallbackSymbol(frameID libpf.FrameID, symbol string
 // ExecutableMetadata accepts a fileID with the corresponding filename
 // and caches this information.
 func (r *OTLPReporter) ExecutableMetadata(fileID libpf.FileID, fileName,
-	buildID string, _ libpf.InterpreterType, _ ExecutableOpener) {
+	buildID string, _ libpf.InterpreterType, _ process.FileOpener) {
 	r.executables.Add(fileID, execInfo{
 		fileName: fileName,
 		buildID:  buildID,

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -23,7 +23,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/nativeunwind/elfunwindinfo"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/process"
 	pm "github.com/open-telemetry/opentelemetry-ebpf-profiler/processmanager"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/support"
 	tracertypes "github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer/types"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/util"
@@ -66,7 +65,7 @@ func newSymbolizationCache() *symbolizationCache {
 }
 
 func (c *symbolizationCache) ExecutableMetadata(fileID libpf.FileID,
-	fileName, _ string, _ libpf.InterpreterType, _ reporter.ExecutableOpener) {
+	fileName, _ string, _ libpf.InterpreterType, _ process.FileOpener) {
 	c.files[fileID] = fileName
 }
 

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/host"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/libpf"
-	"github.com/open-telemetry/opentelemetry-ebpf-profiler/reporter"
+	"github.com/open-telemetry/opentelemetry-ebpf-profiler/process"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/rlimit"
 	"github.com/open-telemetry/opentelemetry-ebpf-profiler/support"
 	tracertypes "github.com/open-telemetry/opentelemetry-ebpf-profiler/tracer/types"
@@ -96,7 +96,7 @@ func (f mockIntervals) PIDCleanupInterval() time.Duration { return 1 * time.Seco
 type mockReporter struct{}
 
 func (f mockReporter) ExecutableMetadata(_ libpf.FileID, _, _ string,
-	_ libpf.InterpreterType, _ reporter.ExecutableOpener) {
+	_ libpf.InterpreterType, _ process.FileOpener) {
 }
 func (f mockReporter) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}
 func (f mockReporter) FrameMetadata(_ libpf.FileID, _ libpf.AddressOrLineno, _ util.SourceLineno,


### PR DESCRIPTION
When uploading elf symbols, it is sometimes necessary to open a file other than the reported executable (eg. to look for separate debug information).