### PR TITLE
Add github action to rebase datadog branch on upstream

### DIFF
--- a/.github/workflows/prepare-rebase-on-upstream.yml
+++ b/.github/workflows/prepare-rebase-on-upstream.yml
@@ -1,0 +1,53 @@
+name: Prepare rebase on upstream
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Set up Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # Do not use `gh repo sync` with GITHUB_TOKEN, it will fail with 422:
+      # {"message":"Repository rule violations found","documentation_url":"https://docs.github.com/rest/branches/branches#sync-a-fork-branch-with-the-upstream-repository","status":"422"}
+      - name: Sync main with upstream
+        run: |
+          git switch main
+          git remote add upstream git@github.com:open-telemetry/opentelemetry-ebpf-profiler.git
+          git fetch upstream
+          git merge --ff upstream/main
+          git push origin
+
+      - name: Checkout datadog branch
+        run: |
+          git switch datadog
+          git pull
+
+      - name: Rebase datadog on main
+        run: |
+          git switch -c rebase-on-upstream
+          git rebase origin/main
+          git push origin rebase-on-upstream
+
+      - name: Create PR
+        run: |
+          gh pr create -R ${{ github.repository }} --base main --head rebase-on-upstream --title "Rebase datadog on upstream/main" --body "This PR is to rebase datadog branch on main branch"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add comment
+        run: |
+          gh pr comment rebase-on-upstream -R ${{ github.repository }} --body "Please close and re-open this PR to trigger the tests."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rebase-on-upstream.yml
+++ b/.github/workflows/rebase-on-upstream.yml
@@ -1,0 +1,79 @@
+name: Rebase on upstream
+
+on:
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Set up Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Check PR
+        id: check_pr
+        run: |
+          # Check that ${{ github.ref_name }} has main as ancestor (ie. fast forward merge is possible)
+          if ! git merge-base --is-ancestor origin/main ${{ github.ref_name }}; then
+            echo "${{ github.ref_name }} does not have main as ancestor"
+            exit 1
+          fi
+
+          gh pr list --state open --head ${{ github.ref_name }} --base main --json number,reviewDecision,state,isDraft,mergeable,statusCheckRollup > pr.json
+          # Check that there is a single PR with main as base branch and ${{ github.ref_name }} as head branch
+          if [[ "$(jq length pr.json)" -eq 0 ]]; then
+            echo "No PR with main as base branch and ${{ github.ref_name }} as head branch"
+            exit 1
+          fi
+          # No need to check that PR count is greater than 1, because github prevents creating multiple PRs with the same head and base branches
+
+          # Check that PR is not draft
+          if [[ "$(jq '.[0] | .isDraft' pr.json)" == "true" ]]; then
+            echo "PR is a draft"
+            exit 1
+          fi
+
+          # Check that PR is mergeable
+          if [[ "$(jq '.[0] | .mergeable' pr.json)" == "false" ]]; then
+            echo "PR is not mergeable"
+            exit 1
+          fi
+
+          # Check that PR is approved
+          if [[ "$(jq -r '.[0] | .reviewDecision' pr.json)" != "APPROVED" ]]; then
+            echo "PR is not approved"
+            exit 1
+          fi
+
+          # Check that PR build is successful, sdm policy check is a bit different from the others
+          unsuccessful_check_count=$(jq '[.[0] | .statusCheckRollup | .[] | select(.workflowName != null and (.status != "COMPLETED" or .conclusion != "SUCCESS") or (.context != null and .state != "SUCCESS"))] | length' pr.json)
+          if [[ "$unsuccessful_check_count" -gt 0 ]]; then
+            echo "PR build is not successful"
+            exit 1
+          fi
+
+          echo "pr_number=$(jq '.[0] | .number' pr.json)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rewrite datadog branch
+        run: |
+          git checkout datadog
+          git reset --hard ${{ github.ref_name }}
+          git push -f
+
+      - name: Close PR and delete update branch
+        run: |
+          gh pr close -d ${{ steps.check_pr.outputs.pr_number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds two manual actions to help with updating `datadog` branch with upstream:
* `prepare-rebase-on-upstream.yml`, this action will
	* sync `main` branch with upstream
	* create a new `rebase-on-upstream` branch based on `datadog` branch
	* attempt to rebase this branch on `main` and if it fails, then it bails out and rebase needs to be done manually
	* if it succeeds, it pushes the branch and open a new PR on `main` branch with the rebased changes.
	Note that this PR needs to be closed and re-open to trigger the build (because pr creation done with a `github_token` cannot trigger events...)
    * this PR is not meant to be merged, it exists only for review/approvel and check that build is successful
* `rebase-on-upstream.yml`, this action will:
    * Check that a PR from the branch this action is run on and targeting `main` branch exists
	* Check that this PR is approved and builds successfully 
	* Force-push changes on `datadog` branch
	* Close PR and delete update branch

Note that these actions cannot be run yet manually from the UI because they don't exist on the default branch (`main`).
We should change the default branch to `datadog`.
These actions use a github deploy key that is in the branch protection rules bypass list in order to be able to force-push.
